### PR TITLE
BM-58515 allow content pipeline projects to ECR

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,10 +6,12 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -18,8 +20,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.ECR_BACKUP_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_BACKUP_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::592115245551:role/github-push-ecr-role
           aws-region: eu-central-1
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
# Description

* Make AWS accessKey/secretkey obsolete

Relates to https://bettermarks.atlassian.net/browse/BM-58515
