### PR TITLE
fix: add --no-owner to enable different db owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
 RUN apt update \
-    && apt install -y gnupg postgresql-common wget \
+    && apt install -y postgresql-common wget \
     && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
     && apt install -y postgresql-client-16 \
     && wget https://dl.minio.io/client/mc/release/linux-amd64/mc -O /sbin/mc \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,24 +2,8 @@
 set -e
 set -o pipefail
 
-# Date function
-get_date () {
-    date +[%Y-%m-%d\ %H:%M:%S]
-}
-
-# Script
-: ${GPG_KEYSERVER:='keyserver.ubuntu.com'}
-: ${GPG_KEYID:=''}
 START_DATE=$(date --utc "+%FT%TZ")
 DUMP=dump-${START_DATE}
-
-if [ -z "$GPG_KEYID" ]
-then
-    echo "$(get_date) !WARNING! It's strongly recommended to encrypt your backups."
-else
-    echo "$(get_date) Preparing keys: importing from keyserver"
-    gpg --keyserver ${GPG_KEYSERVER} --recv-keys ${GPG_KEYID}
-fi
 
 echo "$(get_date) Postgres backup started"
 
@@ -28,8 +12,6 @@ DB_HOST=$(echo -n "${DB_HOST}" | cut -d ':' -f 1)
 export MC_HOST_backup="https://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}@s3.${AWS_REGION}.amazonaws.com"
 export PGPASSWORD="${DB_PASSWORD}"
 
-mc mb backup/${S3_BUCK} --insecure || true
-
 dump_db(){
   DATABASE=$1
   # Ping databaase
@@ -37,14 +19,7 @@ dump_db(){
 
   echo "$(get_date) Dumping database: $DATABASE"
 
-  if [ -z "$GPG_KEYID" ]
-  then
-    pg_dump --format=custom -h "${DB_HOST}" -U "${DB_USER}" -d "${DATABASE}" | mc pipe backup/${S3_BUCK}/${S3_NAME}/${DUMP} --insecure
-  else
-    pg_dump --format=custom -h "${DB_HOST}" -U "${DB_USER}" -d "${DATABASE}" \
-    | gpg --encrypt -z 0 --recipient ${GPG_KEYID} --trust-model always \
-    | mc pipe backup/${S3_BUCK}/${S3_NAME}/${DUMP}.pgp --insecure
-  fi
+  pg_dump --format=custom --no-owner -h "${DB_HOST}" -U "${DB_USER}" -d "${DATABASE}" | mc pipe backup/${S3_BUCK}/${S3_NAME}/${DUMP} --insecure
 }
 
 dump_db "$DB_NAME"


### PR DESCRIPTION
To make things more compatible with the target process, add `--no-owner` so we don't run into restore errors.

Also drop everything related to gnupg encryption as we are not using or supporting that.

https://bettermarks.atlassian.net/browse/BM-63692
